### PR TITLE
Closing </ul> tag in defaut.html

### DIFF
--- a/source/_layouts/default.html
+++ b/source/_layouts/default.html
@@ -40,7 +40,7 @@
 					<ul>
 						<li><a href="{{ root_url }}/">Blog</a></li>
 						<li><a href="{{ root_url }}/blog/archives">Archives</a></li>
-					<ul>
+					</ul>
 				</div> <!-- // .navi -->
 			</header>
 		


### PR DESCRIPTION
Love this theme, just noticed an unclosed `<ul>` tag.

Also would you be open to a second PR that moves the [navigation in `default.html`](https://github.com/elisehein/Pageturner/blob/master/source/_layouts/default.html#L39) to a partial in the `includes` directory (so it matches [Octopress' instructions to customizing navigation](http://octopress.org/docs/theme/template/#changing_navigation))?
